### PR TITLE
chore: use DuckDB jsdelivr bundle instead of local

### DIFF
--- a/.changeset/famous-weeks-camp.md
+++ b/.changeset/famous-weeks-camp.md
@@ -1,0 +1,5 @@
+---
+"uchimata": patch
+---
+
+Change to using jsdelivr duckdb bundle to reduce size

--- a/src/selections/DuckDBClient.ts
+++ b/src/selections/DuckDBClient.ts
@@ -20,12 +20,14 @@ export class DuckDBSingleton {
 
       const JSDELIVR_BUNDLES = duckdb.getJsDelivrBundles();
       const bundle = await duckdb.selectBundle(JSDELIVR_BUNDLES);
-      const worker_url = URL.createObjectURL(
-        new Blob([`importScripts("${bundle.mainWorker!}");`], { type: 'text/javascript' })
-      );
       if (!bundle.mainWorker) {
         throw new Error("DuckDB bundle does not contain a main worker");
       }
+      const worker_url = URL.createObjectURL(
+        new Blob([`importScripts("${bundle.mainWorker}");`], {
+          type: "text/javascript",
+        }),
+      );
       const worker = new Worker(worker_url);
       const logger = new duckdb.ConsoleLogger();
 


### PR DESCRIPTION
Finally figured out how to use the JSDELIVR bundle with vite. Key code snippet was this one: https://duckdb.org/docs/stable/clients/wasm/instantiation.html#cdnjsdelivr
Previously had issues getting things working using just the code from the duckdb-wasm announcement: https://duckdb.org/2021/10/29/duckdb-wasm.html#advanced-features

This change should make the uchimata bundle much much smaller (current version on npm is 96.2 MB!)