### PR TITLE
Replace apache-arrow with flechette

### DIFF
--- a/.changeset/hot-swans-stay.md
+++ b/.changeset/hot-swans-stay.md
@@ -1,0 +1,5 @@
+---
+"uchimata": patch
+---
+
+replace apache-arrow with flechette for arrow IPC parsing

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   "dependencies": {
     "@duckdb/duckdb-wasm": "1.29.1-dev132.0",
     "@preact/signals-core": "^1.11.0",
-    "apache-arrow": "^17.0.0",
+    "@uwdata/flechette": "^2.2.3",
     "chroma-js": "^3.1.2",
     "gl-matrix": "^3.4.3",
     "n8ao": "^1.10.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,9 +14,9 @@ importers:
       '@preact/signals-core':
         specifier: ^1.11.0
         version: 1.11.0
-      apache-arrow:
-        specifier: ^17.0.0
-        version: 17.0.0
+      '@uwdata/flechette':
+        specifier: ^2.2.3
+        version: 2.2.3
       chroma-js:
         specifier: ^3.1.2
         version: 3.1.2
@@ -617,6 +617,9 @@ packages:
 
   '@types/webxr@0.5.19':
     resolution: {integrity: sha512-4hxA+NwohSgImdTSlPXEqDqqFktNgmTXQ05ff1uWam05tNGroCMp4G+4XVl6qWm1p7GQ/9oD41kAYsSssF6Mzw==}
+
+  '@uwdata/flechette@2.2.3':
+    resolution: {integrity: sha512-5qMO+KT+udDFwgh+HxQ2memj27bPeCXlJ7bWnmI1wvW8RaoHhSJtI7PHVDd2AONhqXuuDLVkWKaV0G51ozrpWw==}
 
   '@vitest/expect@3.2.4':
     resolution: {integrity: sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==}
@@ -2042,6 +2045,8 @@ snapshots:
       meshoptimizer: 0.18.1
 
   '@types/webxr@0.5.19': {}
+
+  '@uwdata/flechette@2.2.3': {}
 
   '@vitest/expect@3.2.4':
     dependencies:

--- a/src/__tests__/chromatin.test.ts
+++ b/src/__tests__/chromatin.test.ts
@@ -1,4 +1,4 @@
-import { type Table, tableFromArrays } from "apache-arrow";
+import { type Table, tableFromArrays } from "@uwdata/flechette";
 import chroma from "chroma-js";
 import { beforeEach, describe, expect, test } from "vitest";
 import { assert } from "../assert.ts";

--- a/src/chromatin-types.ts
+++ b/src/chromatin-types.ts
@@ -1,4 +1,4 @@
-import type { Table } from "apache-arrow";
+import type { Table } from "@uwdata/flechette";
 import type { vec3 } from "gl-matrix";
 
 /**

--- a/src/chromatin.ts
+++ b/src/chromatin.ts
@@ -140,7 +140,7 @@ export function resolveScale(table: Table, vc: ViewConfig): number | number[] {
     const fieldName = vc.scale.field;
     const valuesColumn = table.getChild(fieldName);
     if (valuesColumn) {
-      scale = mapValuesToScale(valuesColumn.toArray(), vc.scale);
+      scale = mapValuesToScale(Array.from(valuesColumn.toArray()), vc.scale);
     }
   } else {
     //~ scale is an array of numbers
@@ -287,7 +287,7 @@ export function resolveColor(
     if (!valuesColumn) {
       throw new Error(`Field '${fieldName}' not found in table`);
     }
-    color = mapValuesToColors(valuesColumn.toArray(), vc.color);
+    color = mapValuesToColors(Array.from(valuesColumn.toArray()), vc.color);
   } else {
     //~ color should be based on values in the 'values' array
     if (!vc.color.values) {
@@ -313,14 +313,18 @@ function buildDisplayableStructure(
   const yCol = structure.structure.data.getChild("y");
   const zCol = structure.structure.data.getChild("z");
   assert(xCol && yCol && zCol, "x, y, z columns must be present in data");
-  const xArr = xCol.toArray();
-  const yArr = yCol.toArray();
-  const zArr = zCol.toArray();
+  const xArr = Array.from(xCol.toArray()) as number[];
+  const yArr = Array.from(yCol.toArray()) as number[];
+  const zArr = Array.from(zCol.toArray()) as number[];
 
   const chrColumn = structure.structure.data.getChild("chr");
-  const chrArr = chrColumn ? (chrColumn.toArray() as string[]) : undefined;
+  const chrArr = chrColumn
+    ? (Array.from(chrColumn.toArray()) as string[])
+    : undefined;
   const idxColumn = structure.structure.data.getChild("index");
-  const idxArr = idxColumn ? (idxColumn.toArray() as number[]) : undefined;
+  const idxArr = idxColumn
+    ? (Array.from(idxColumn.toArray()) as number[])
+    : undefined;
 
   const positions: vec3[] = [];
   for (let i = 0; i < structure.structure.data.numRows; i++) {

--- a/src/chromatin.ts
+++ b/src/chromatin.ts
@@ -1,4 +1,4 @@
-import type { Table } from "apache-arrow";
+import type { Table } from "@uwdata/flechette";
 import type { Color as ChromaColor } from "chroma-js";
 import chroma from "chroma-js";
 import { vec3 } from "gl-matrix";

--- a/src/data-loaders/arrow.ts
+++ b/src/data-loaders/arrow.ts
@@ -45,9 +45,15 @@ function recenterXYZColumns(table: Table): Table {
   assert(columnNames.includes("y"), "y column is missing");
   assert(columnNames.includes("z"), "z column is missing");
 
-  const newXCol = recenterSingleColumn(table.getChild("x")?.toArray());
-  const newYCol = recenterSingleColumn(table.getChild("y")?.toArray());
-  const newZCol = recenterSingleColumn(table.getChild("z")?.toArray());
+  const newXCol = recenterSingleColumn(
+    Array.from(table.getChild("x")?.toArray()),
+  );
+  const newYCol = recenterSingleColumn(
+    Array.from(table.getChild("y")?.toArray()),
+  );
+  const newZCol = recenterSingleColumn(
+    Array.from(table.getChild("z")?.toArray()),
+  );
 
   //~ building in object of arrays from the original table
   const fields = table.schema.fields;
@@ -137,9 +143,9 @@ function saveOriginalXYZ(table: Table): Table {
   //~ reassemble the table with duplicated x, y, z columns (as xRaw, yRaw, zRaw)
   return tableFromArrays({
     ...oldTableObject,
-    xRaw: xColAsArray,
-    yRaw: yColAsArray,
-    zRaw: zColAsArray,
+    xRaw: Array.from(xColAsArray),
+    yRaw: Array.from(yColAsArray),
+    zRaw: Array.from(zColAsArray),
   });
 }
 

--- a/src/data-loaders/arrow.ts
+++ b/src/data-loaders/arrow.ts
@@ -1,4 +1,4 @@
-import { type Table, tableFromArrays, tableFromIPC } from "apache-arrow";
+import { type Table, tableFromArrays, tableFromIPC } from "@uwdata/flechette";
 import { vec3 } from "gl-matrix";
 import { assert } from "../assert.ts";
 import type { ChromatinStructure } from "../chromatin-types";

--- a/src/data-loaders/loader-utils.ts
+++ b/src/data-loaders/loader-utils.ts
@@ -1,29 +1,9 @@
-import type { Schema } from "apache-arrow";
 import { vec3 } from "gl-matrix";
 
 export type LoadOptions = {
   center?: boolean;
   normalize?: boolean;
 };
-
-/**
- * Will return true if the table schema contains only 3 columns named x, y, z
- */
-export function isChunk(tableSchema: Schema): boolean {
-  return tableSchema.fields.length === 3 && hasXYZ(tableSchema);
-}
-
-/**
- * Returns true when table schema contains x, y, z fields
- */
-export function hasXYZ(tableSchema: Schema): boolean {
-  const columnNames = tableSchema.fields.map((f) => f.name);
-  return (
-    columnNames.includes("x") &&
-    columnNames.includes("y") &&
-    columnNames.includes("z")
-  );
-}
 
 export const recenter = (originalPositions: vec3[]): vec3[] => {
   const positions = originalPositions;

--- a/src/selections/selections.ts
+++ b/src/selections/selections.ts
@@ -1,6 +1,6 @@
 import { type Table, tableToIPC } from "@uwdata/flechette";
-import { DuckDBSingleton } from "./DuckDBClient";
 import { assert } from "../assert";
+import { DuckDBSingleton } from "./DuckDBClient";
 
 const duckDB = new DuckDBSingleton();
 

--- a/src/selections/selections.ts
+++ b/src/selections/selections.ts
@@ -1,5 +1,6 @@
 import { type Table, tableToIPC } from "@uwdata/flechette";
 import { DuckDBSingleton } from "./DuckDBClient";
+import { assert } from "../assert";
 
 const duckDB = new DuckDBSingleton();
 
@@ -15,7 +16,9 @@ export async function makeCuttingPlane(
   if (!(await duckDB.getExistingTables()).includes("structure")) {
     const db = await duckDB.getDatabase();
     const conn = await db.connect();
-    conn.insertArrowFromIPCStream(tableToIPC(model), { name: "structure" });
+    const tableAsIPC = tableToIPC(model, {});
+    assert(tableAsIPC, "Failed to convert model to IPC format");
+    conn.insertArrowFromIPCStream(tableAsIPC, { name: "structure" });
   }
 
   const query = invert
@@ -39,7 +42,9 @@ export async function selectChromosome(
   if (!(await duckDB.getExistingTables()).includes("structure")) {
     const db = await duckDB.getDatabase();
     const conn = await db.connect();
-    conn.insertArrowFromIPCStream(tableToIPC(model), { name: "structure" });
+    const tableAsIPC = tableToIPC(model, {});
+    assert(tableAsIPC, "Failed to convert model to IPC format");
+    conn.insertArrowFromIPCStream(tableAsIPC, { name: "structure" });
   }
 
   const query = `SELECT * FROM structure WHERE ${column} ='${chromName}'`;
@@ -59,7 +64,9 @@ export async function selectRange(
   if (!(await duckDB.getExistingTables()).includes("structure")) {
     const db = await duckDB.getDatabase();
     const conn = await db.connect();
-    conn.insertArrowFromIPCStream(tableToIPC(model), { name: "structure" });
+    const tableAsIPC = tableToIPC(model, {});
+    assert(tableAsIPC, "Failed to convert model to IPC format");
+    conn.insertArrowFromIPCStream(tableAsIPC, { name: "structure" });
   }
 
   const query = `SELECT * FROM structure WHERE ${chromColumn} ='${chromName}' AND ${coordinateColumn} >= ${start} AND ${coordinateColumn} <= ${end}`;
@@ -78,7 +85,9 @@ export async function sphereSelect(
   if (!(await duckDB.getExistingTables()).includes("structure")) {
     const db = await duckDB.getDatabase();
     const conn = await db.connect();
-    conn.insertArrowFromIPCStream(tableToIPC(model), { name: "structure" });
+    const tableAsIPC = tableToIPC(model, {});
+    assert(tableAsIPC, "Failed to convert model to IPC format");
+    conn.insertArrowFromIPCStream(tableAsIPC, { name: "structure" });
   }
 
   const query = `SELECT * FROM structure WHERE POWER(x - ${x}, 2) + POWER(y - ${y}, 2) + POWER(z - ${z}, 2) <= POWER(${radius}, 2)`;

--- a/src/selections/selections.ts
+++ b/src/selections/selections.ts
@@ -1,4 +1,4 @@
-import { type Table, tableToIPC } from "apache-arrow";
+import { type Table, tableToIPC } from "@uwdata/flechette";
 import { DuckDBSingleton } from "./DuckDBClient";
 
 const duckDB = new DuckDBSingleton();


### PR DESCRIPTION
Main (initial) motivation was that duckdb-wasm requires apache-arrow@17.0.0, and there's always a lingering dependabot PR that wants to update. 

I also subjectively like flechette better. Mosaic has been using it with duckdb-wasm, and it looks like the change needed is pretty minimal.